### PR TITLE
Update skr 1.3 extruder currents

### DIFF
--- a/firmware_configurations/klipper/eddie/Voron2_SKR_Universal_Config.cfg
+++ b/firmware_configurations/klipper/eddie/Voron2_SKR_Universal_Config.cfg
@@ -303,8 +303,8 @@ pressure_advance_smooth_time: 0.040
 uart_pin: P1.9
 microsteps: 16
 interpolate: false
-run_current: 1.0
-hold_current: 1.0
+run_current: 0.5
+hold_current: 0.4
 sense_resistor: 0.110
 stealthchop_threshold: 0
 


### PR DESCRIPTION
  * [x] The mod, firmware configuration or slicer profile is in the correct category
    folder. Printable mods go to `printer_mods/`, firmware configurations
    go to `firmware_configurations/`, slicer profiles go to `slicer_profiles/`.
    Create a subfolder with your name, and place the mods in a subfolder with
    a descriptive name within that folder, e.g.: `/printer_mods/FHeilmann/flux_capacitor`
  * [x] Folders names MUST NOT contain spaces. If possible, make sure file names also 
    do not contain any spaces.
  * [x] For each mod, add a small `README.md` file to its folder with a short description
    of what the mod accomplishes. This readme can be used to add pictures, give assembly
    instructions or specify a bill of materials if the mod requires additional hardware.
  * [x] The PR modifies the top-level `README.md` of the category folder adding the 
    contribution to the table. Read the top part of the file for instructions on how
    to do this. Please preserve the alphabetical ordering while adding new rows. Make sure
    to fill out the compatibility matrix to indicate which versions of the Voron printer
    the submission is compatible with.
  * [x] The mod/configuration/profile has been tested by the person submitting the mod 
    and/or other Voron users. Make sure to add information about how the mod was tested below. 
  * [x] The mod is not merely a slight modification of an official Voron part, configuration 
    or profile (i.e. an official Voron part with a few mm added or removed or a slicer profile 
    which only modifies a few values). *(When in doubt, contact one of the admins in the 
    Voron discord before submitting the PR)*
  * [x] Submitted STLs are printable without support. *(If the mod does not meet this criterion
    join the Voron discord and ask the other users for advice on how to modify the mod such 
    that it does not require supports)*
  * [x] Submitted STL files are not corrupt. *(This can be tested by opening the STL in PrusaSlicer
    and checking if mesh errors are reported.)*
  * [x] Submitted STL files are oriented and scaled properly for printing.
  * [x] Submitted firmware configs or slicer profiles contain no sensitive data (e.g. API keys).

This changes the SKR 1.3 run and hold current to match the config in
the Voron-2 repo and the SKR 1.4 repo. The 1A currents listed here can
lead to the extruder stepper getting hot enough to melt the extruder
body.  Based on feedback in Discord, this appears to be a problem a few
people have had.

#### Which mods/configurations/profiles are added by this PR?

SKR 1.3 config

#### How was it tested? 

Printing things!

#### Any back ground context you want to provide?

I melted my extruder body, even with the currents set lower than this.

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/27088/102911670-5b99b200-444a-11eb-9adf-8c809436bf6b.png)


#### Further notes
