### PR TITLE
Purge Bucket - Fixes & Features Additions In Macros

### DIFF
--- a/printer_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
+++ b/printer_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
@@ -161,7 +161,7 @@ gcode:
          {% endif %}
 
          ### Position for purge. Randomly selects middle of left or right bucket. It references from the middle of the left bucket.
-         G1 X{bucket_start + (bucket_left_width / (2 - bucket_pos) + (bucket_pos * bucket_gap) + (bucket_pos * (bucket_right_width / 2))}
+         G1 X{bucket_start + (bucket_left_width / (2 - bucket_pos)) + (bucket_pos * bucket_gap) + (bucket_pos * (bucket_right_width / 2))}
 
          ### Perform purge if the temp is up to min temp. If not, it will skip and continue executing rest of macro.
          {% if printer.extruder.temperature >= purge_temp_min %}

--- a/printer_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
+++ b/printer_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
@@ -38,7 +38,7 @@ variable_enable_purge:              True
 
 # These parameters define your filament purging. Update as necessary. If you decided to not enable purge, you can ignore this section.
 variable_purge_len:            10	         ; Amount of filament, in mm, to purge.
-variable_purge_spd:           150	         ; Speed, in mm/s, of the purge.
+variable_purge_spd:           150	         ; Speed, in mm/min, of the purge.
 variable_purge_temp_min:      240	         ; Minimum nozzle temperature to permit a purge. Otherwise, purge will not occur.
 
 # Adjust this so that your nozzle scrubs within the brush. Currently defaulted to be a lot higher for safety. Be careful not to go too low!
@@ -161,7 +161,7 @@ gcode:
          {% endif %}
 
          ### Position for purge. Randomly selects middle of left or right bucket. It references from the middle of the left bucket.
-         G1 X{bucket_start + (bucket_left_width / 2) + (bucket_pos * bucket_gap) + (bucket_pos * (bucket_right_width / 2))}
+         G1 X{bucket_start + (bucket_left_width / (2 - bucket_pos) + (bucket_pos * bucket_gap) + (bucket_pos * (bucket_right_width / 2))}
 
          ### Perform purge if the temp is up to min temp. If not, it will skip and continue executing rest of macro.
          {% if printer.extruder.temperature >= purge_temp_min %}

--- a/printer_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
+++ b/printer_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
@@ -148,7 +148,7 @@ gcode:
       {% if enable_purge %}
 
          ### Randomly select left or right bin for purge. 
-         SET_GCODE_VARIABLE MACRO=clean_nozzle VARIABLE=bucket_pos VALUE={(range(0, 1) | random)}
+         SET_GCODE_VARIABLE MACRO=clean_nozzle VARIABLE=bucket_pos VALUE={(range(2) | random)}
 
          ### Raise Z for travel.
          G1 Z{brush_top + clearance_z} F{prep_spd_z}

--- a/printer_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
+++ b/printer_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
@@ -1,26 +1,30 @@
 #######################################################################################################################################
 
 # Sample macro config to be used in conjunction with the Decontaminator Purge Bucket & Nozzle Scrubber mod. Created by Hernsl 
-# (hernsl#8860 on Voron Design discord) and edited by Edwardyeeks (edwardyeeks#6042 on Voron Design Discord).
+# (hernsl#8860 on Discord) and edited by Edwardyeeks (edwardyeeks#6042 on Discord). Several ideas that made it as features by
+# Deutherius (deutherius#3295 on Discord).
 
 # The goal of this macro is to provide a nozzle scrubbing and purging routine that is easily copied/referenced into your  printer.cfg.
-# Users can simply change parameters and enable/disable options in the first half. Descriptions are laid out in sequence to be read
-# first; PLEASE READ CAREFULLY.
+# Users can simply change parameters and enable/disable options in the first half. Descriptions are plentiful, making this macro
+# look huge but informative and are laid out in sequence to be read first describing the line below; PLEASE READ CAREFULLY.
 
 # This sample config assumes the following: The user has implemented the default decontaminator purge bucket & nozzle scrubber mod
-# for the VORON 1/2.
+# for the VORON 1/2. It can be tweaked to customised purge bucket geometries and brushes.
 
 # Features in this macro: option of putting the bucket at the rear or front of the bed. Purge routine that can be enabled/disabled.
-# By default, bucket is located at rear left of bed and purge routine is enabled.
+# By default, bucket is located at rear left of bed and purge routine is enabled. The purge and scrubbing routine is randomized
+# in either left or right bucket to ensure as even as possible distribution of filament gunk.
 
 # Default parameters are set for safe speeds and movements. Where necessary, tweak the parameters for the nozzle scrub procedure 
 # to fit your printer.
 
 # To avoid adding length of lines to your main printer.cfg config file, one can upload a config file separately into klipper and
 # include it into the main printer config. Upload nozzle_scrub.cfg to the same directory as printer.cfg. Usually, it is in /home/pi/.
+# Users of Fluidd, Mainsail and other klipper front ends would find it under /home/pi/klipper_config/.
 
 # Once uploaded, add the following to your printer.cfg in the Macros section: [include /home/pi/nozzle_scrub.cfg] 
-# Those running mainsail will need to use the following location instead: [include /home/pi/klipper_config/nozzle_scrub.cfg]
+# Those running Fluidd, Mainsail and other front ends will need to use the following location instead:
+# [include /home/pi/klipper_config/nozzle_scrub.cfg]
 
 #######################################################################################################################################
 
@@ -36,17 +40,22 @@ variable_location_bucket_rear:      True
 # If you want the purging routine in your bucket enabled, set to True (and vice versa).
 variable_enable_purge:              True
 
-# These parameters define your filament purging. Update as necessary. If you decided to not enable purge, you can ignore this section.
+# These parameters define your filament purging. The retract variable is used to retract right after purging to prevent unnecessary
+# oozing. Some filament are particularly oozy and may continue to ooze out of the nozzle for a second or two after retracting. The
+# ooze dwell variable makes allowance for this. Update as necessary. If you decided to not enable purge, you can ignore this section.
 variable_purge_len:            10	         ; Amount of filament, in mm, to purge.
 variable_purge_spd:           150	         ; Speed, in mm/min, of the purge.
 variable_purge_temp_min:      240	         ; Minimum nozzle temperature to permit a purge. Otherwise, purge will not occur.
+variable_purge_ret:             2            ; Retract length, in mm, after purging to prevent slight oozing. Adjust as necessary.
+variable_ooze_dwell:            2            ; Dwell/wait time, in seconds, after purging and retracting.
 
 # Adjust this so that your nozzle scrubs within the brush. Currently defaulted to be a lot higher for safety. Be careful not to go too low!
 variable_brush_top:            10 
 
-# These parameters define your scrubbing, travel speeds, safe z clearance and how many times you want to wipe. Update as necessary.
+# These parameters define your scrubbing, travel speeds, safe z clearance and how many times you want to wipe. Update as necessary. Wipe 
+# direction is randomized based off whether the left or right bucket is randomly selected in the purge & scrubbing routine.
 variable_clearance_z:           5	         ; When traveling, but not cleaning, the clearance along the z-axis between nozzle and brush.
-variable_wipe_qty:              3	         ; Number of complete (A complete wipe: start left, go right, go left) wipes.
+variable_wipe_qty:              3	         ; Number of complete (A complete wipe: left, right, left OR right, left, right) wipes.
 variable_prep_spd_xy:        3000	         ; Travel (not cleaning) speed along x and y-axis in mm/min.
 variable_prep_spd_z:         1500	         ; Travel (not cleaning) speed along z axis in mm/min.
 variable_wipe_spd_xy:        5000	         ; Nozzle wipe speed in mm/min.
@@ -123,12 +132,13 @@ variable_bucket_start: 0
 ###############################################################################################################################################
 ###############################################################################################################################################
 
-### From here on, unless you know what you're doing, it's recommended not to change anything.
+### From here on, unless you know what you're doing, it's recommended not to change anything. Feel free to peruse the code and reach out to me
+### (edwardyeeks#6042) on Discord if you spot any problems!
 
 ###############################################################################################################################################
 ###############################################################################################################################################
 
-# Placeholder. The variable will contain at random a number representing the left or right bucket.
+# Placeholder. The variable will later be set to contain, at random, a number representing the left or right bucket.
 variable_bucket_pos:            1	        
 
 gcode:
@@ -147,7 +157,7 @@ gcode:
       ## Check if user enabled purge option or not.
       {% if enable_purge %}
 
-         ### Randomly select left or right bin for purge. 
+         ### Randomly select left or right bin for purge. 0 = left, 1 = right
          SET_GCODE_VARIABLE MACRO=clean_nozzle VARIABLE=bucket_pos VALUE={(range(2) | random)}
 
          ### Raise Z for travel.
@@ -163,18 +173,21 @@ gcode:
          ### Position for purge. Randomly selects middle of left or right bucket. It references from the middle of the left bucket.
          G1 X{bucket_start + (bucket_left_width / (2 - bucket_pos)) + (bucket_pos * bucket_gap) + (bucket_pos * (bucket_right_width / 2))}
 
-         ### Perform purge if the temp is up to min temp. If not, it will skip and continue executing rest of macro.
+         ### Perform purge if the temp is up to min temp. If not, it will skip and continue executing rest of macro. Small retract after
+         ### purging to minimize any persistent oozing at 5x purge_spd. G4 dwell is in milliseconds, hence * 1000 in formula.
          {% if printer.extruder.temperature >= purge_temp_min %}
             M83      ; relative mode
             G1 E{purge_len} F{purge_spd}
+            G1 E-{purge_ret} F{purge_spd * 5}
+            G4 P{ooze_dwell * 1000}
             G92 E0   ; reset extruder
          {% endif %}
 
       {% endif %}
    
-      ## Position for wipe.
+      ## Position for wipe. Either left or right of brush based off bucket_pos to avoid unnecessary travel.
       G1 Z{brush_top + clearance_z} F{prep_spd_z}
-      G1 X{brush_start} F{prep_spd_xy}
+      G1 X{brush_start + (brush_width * bucket_pos)} F{prep_spd_xy}
 
       ## Check if user chose to use rear location.
       {% if location_bucket_rear %}
@@ -186,10 +199,10 @@ gcode:
       ## Move nozzle down into brush.
       G1 Z{brush_top} F{prep_spd_z}
    
-      ## Perform wipe.
+      ## Perform wipe. Wipe direction based off bucket_pos for cool random scrubby routine.
       {% for wipes in range(1, (wipe_qty + 1)) %}
-         G1 X{brush_start + brush_width} F{wipe_spd_xy}
-         G1 X{brush_start} F{wipe_spd_xy}
+         G1 X{brush_start + (brush_width * (1 - bucket_pos))} F{wipe_spd_xy}
+         G1 X{brush_start + (brush_width * bucket_pos)} F{wipe_spd_xy}
       {% endfor %}
    
       ## Clear from area.


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to the VoronUsers repository, it is
highly appreciated!

**Please make sure the submission conforms to the rules outlined below. PRs which fail
to conform to the rules below are likely to be rejected.**
-->

  * [x] The mod, firmware configuration or slicer profile is in the correct category
    folder. Printable mods go to `printer_mods/`, firmware configurations
    go to `firmware_configurations/`, slicer profiles go to `slicer_profiles/`.
    Create a subfolder with your name, and place the mods in a subfolder with
    a descriptive name within that folder, e.g.: `/printer_mods/FHeilmann/flux_capacitor`
  * [x] Folders names MUST NOT contain spaces. If possible, make sure file names also 
    do not contain any spaces.
  * [x] For each mod, add a small `README.md` file to its folder with a short description
    of what the mod accomplishes. This readme can be used to add pictures, give assembly
    instructions or specify a bill of materials if the mod requires additional hardware.
  * [x] The PR modifies the top-level `README.md` of the category folder adding the 
    contribution to the table. Read the top part of the file for instructions on how
    to do this. Please preserve the alphabetical ordering while adding new rows. Make sure
    to fill out the compatibility matrix to indicate which versions of the Voron printer
    the submission is compatible with.
  * [x] The mod/configuration/profile has been tested by the person submitting the mod 
    and/or other Voron users. Make sure to add information about how the mod was tested below. 
  * [x] The mod is not merely a slight modification of an official Voron part, configuration 
    or profile (i.e. an official Voron part with a few mm added or removed or a slicer profile 
    which only modifies a few values). *(When in doubt, contact one of the admins in the 
    Voron discord before submitting the PR)*
  * [x] Submitted STLs are printable without support. *(If the mod does not meet this criterion
    join the Voron discord and ask the other users for advice on how to modify the mod such 
    that it does not require supports)*
  * [x] Submitted STL files are not corrupt. *(This can be tested by opening the STL in PrusaSlicer
    and checking if mesh errors are reported.)*
  * [x] Submitted STL files are oriented and scaled properly for printing.

<!--
Describe the submission further using the template provided below. The more 
details the better!
-->

#### Which mods/configurations/profiles are added by this PR?
Decontaminator Purge Bucket & Nozzle Scrubber. Fix error in script defining random selection of bucket halves for purging. The issue was that when selecting the right half of the bucket to randomly purge, it would put the nozzle too close/within the brush; it should now be fixed. Small speed unit correction. (thanks Deutherius#3295 on VD discord for pointing these out).
