### PR TITLE
Updated link to the PCB in Voron-Hardware

### DIFF
--- a/printer_mods/randell/Microswitch_Endstop/README.md
+++ b/printer_mods/randell/Microswitch_Endstop/README.md
@@ -1,7 +1,7 @@
 # Voron 2.4 XY Microswitch Endstop for PCB
 POD for use with the Microswitch endstop pcb board for X and Y axes.
 
-Check https://github.com/VoronDesign/Voron-Hardware for the microswitch pcb.
+Check [Microswitch_Endstop](https://github.com/VoronDesign/Voron-Hardware/tree/master/Microswitch_Endstop) for the microswitch pcb.
 
 ![Installed](Images/picture2.jpg?raw=true "Installed")
 ![Mounted 1](Images/picture1.jpg?raw=true "Mounted 2")


### PR DESCRIPTION
Updated the link to more easily find the PCB in Voron-Hardware. A similar change was made there to more easily find the STL for the pod (this)