### PR TITLE
Fix reversal of UARTs for z2/z3

### DIFF
--- a/firmware_configurations/klipper/RealDeuce/MKS-Makerbase/Monster8_v1.0_003/Voron2_Monster8_Config.cfg
+++ b/firmware_configurations/klipper/RealDeuce/MKS-Makerbase/Monster8_v1.0_003/Voron2_Monster8_Config.cfg
@@ -178,7 +178,7 @@ gear_ratio: 80:16
 microsteps: 16
 
 [tmc2209 stepper_z2]
-uart_pin: PD0
+uart_pin: PD4
 interpolate: False
 run_current: 0.8                # Max 1.4 (tmc2209 limit)
 sense_resistor: 0.110
@@ -194,7 +194,7 @@ gear_ratio: 80:16
 microsteps: 16
 
 [tmc2209 stepper_z3]
-uart_pin: PD4
+uart_pin: PD0
 interpolate: False
 run_current: 0.8                # Max 1.4 (tmc2209 limit)
 sense_resistor: 0.110


### PR DESCRIPTION
  * [√] The mod, firmware configuration or slicer profile is in the correct category
    folder. Printable mods go to `printer_mods/`, firmware configurations
    go to `firmware_configurations/`, slicer profiles go to `slicer_profiles/`.
    Create a subfolder with your name, and place the mods in a subfolder with
    a descriptive name within that folder, e.g.: `/printer_mods/FHeilmann/flux_capacitor`
  * [√] Folders names MUST NOT contain spaces. If possible, make sure file names also 
    do not contain any spaces.
  * [√] For each mod, add a small `README.md` file to its folder with a short description
    of what the mod accomplishes. This readme can be used to add pictures, give assembly
    instructions or specify a bill of materials if the mod requires additional hardware.
  * [√] The PR modifies the top-level `README.md` of the category folder adding the 
    contribution to the table. Read the top part of the file for instructions on how
    to do this. Please preserve the alphabetical ordering while adding new rows. Make sure
    to fill out the compatibility matrix to indicate which versions of the Voron printer
    the submission is compatible with.
  * [√] The mod/configuration/profile has been tested by the person submitting the mod 
    and/or other Voron users. Make sure to add information about how the mod was tested below. 
  * [√] The mod is not merely a slight modification of an official Voron part, configuration 
    or profile (i.e. an official Voron part with a few mm added or removed or a slicer profile 
    which only modifies a few values). *(When in doubt, contact one of the admins in the 
    Voron discord before submitting the PR)*
  * [√] Submitted STLs are printable without support. *(If the mod does not meet this criterion
    join the Voron discord and ask the other users for advice on how to modify the mod such 
    that it does not require supports)*
  * [√] Submitted STL files are not corrupt. *(This can be tested by opening the STL in PrusaSlicer
    and checking if mesh errors are reported.)*
  * [√] Submitted STL files are oriented and scaled properly for printing.
  * [√] Submitted firmware configs or slicer profiles contain no sensitive data (e.g. API keys).

#### Which mods/configurations/profiles are added by this PR?
None, update only.

#### How was it tested? 
Used STEPPER_BUZZ to bounce the steppers, the DUMP_TMC to verify that IFCNT incremented on only the correct stepper.

#### Any background context you want to provide?
UART pins were reversed for stepper_z2 and stepper_z3.  If the configurations for these steppers were not the same, this would have resulted in incorrect settings for the stepper.  Also, errors due to miswired steppers etc. would be attributed to the wrong stepper driver.

#### Screenshots (if appropriate)

#### Further notes
