### PR TITLE
firmware_configurations/klipper: Fysetc S6 V2.1

### DIFF
--- a/firmware_configurations/README.md
+++ b/firmware_configurations/README.md
@@ -27,6 +27,7 @@ like so:
 
 | Creator | Config title | Description | V0 | V1.8 | V2.4 | VSW | VT |
 | --- | --- | --- | --- | --- | --- | --- | --- |
+| clee | [Fysetc S6 V2.1 for V0.1](./klipper/clee/fysetc_s6) | Example configuration and board pin aliases for the Fysetc S6 V2.1 for V0.1 | :heavy_check_mark: | :x: | :x: | :x: | :x: |
 | jaeger | [FYSETC Spider on V1.8](./klipper/jaeger/Spider_1.1_V1.8) | Example configuration and wiring diagram for a FYSETC Spider 1.1 board on the V1.8 | :x: | :heavy_check_mark: | :x: | :x: | :x: |
 | MarcPot | [Fysetc Spider Board Pins](./klipper/MarcPot/fysetc_spider_pins) | Defines a set of `[board_pins]` aliases for use with the Fysetc Spider controller | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: |
 | Mellow | [Fly-Super8 on V2.4](./klipper/Mellow/FLY-Super8) | Example configuration and wiring diagram for a FLY-Super8 board on the V2.4 | :x: | :x: | :heavy_check_mark: | :x: | :x: |

--- a/firmware_configurations/klipper/clee/fysetc_s6/fysetc_s6_v2.1_pin_aliases.cfg
+++ b/firmware_configurations/klipper/clee/fysetc_s6/fysetc_s6_v2.1_pin_aliases.cfg
@@ -1,0 +1,53 @@
+#####################################################################
+#   FYSETC S6 V2.1 Pin Aliases
+#####################################################################
+
+[board_pins]
+aliases:
+    # Stepper drivers
+    MOT0_EN=PE9,  MOT0_STEP=PE11, MOT0_DIR=PE10, MOT0_CS=PE8,   # X
+    MOT1_EN=PD9,  MOT1_STEP=PD8,  MOT1_DIR=PB12, MOT1_CS=PC4,   # Y
+    MOT2_EN=PD15, MOT2_STEP=PD14, MOT2_DIR=PD13, MOT2_CS=PD12,  # Z
+    MOT3_EN=PD4,  MOT3_STEP=PD5,  MOT3_DIR=PD6,  MOT3_CS=PA15,  # E0
+    MOT4_EN=PE5,  MOT4_STEP=PE6,  MOT4_DIR=PC13, MOT4_CS=PC5,   # E1
+    MOT5_EN=PE3,  MOT5_STEP=PE2,  MOT5_DIR=PE4,  MOT5_CS=PE0,   # E2
+
+    # Heaters
+    BED_OUT=PC8,
+    HE0=PB3,
+    HE1=PB4,
+    HE2=PB15,
+
+    # Thermistors
+    TB=PC3,
+    T0=PC0,
+    T1=PC1,
+    T2=PC2,
+
+    # Fans
+    FAN0=PB0,
+    FAN1=PB1,
+    FAN2=PB2,
+
+    # End stops
+    ESTOP0=PB14,
+    ESTOP1=PB13,
+    ESTOP2=PA0,
+    ESTOP3=PA3,
+    ESTOP4=PA2,
+    ESTOP5=PA1,
+
+    # EXP1 header
+    EXP1_1=PC9,   EXP1_2=PA8,
+    EXP1_3=PC11,  EXP1_4=PD2,
+    EXP1_5=PC10,  EXP1_6=PC12,
+    EXP1_7=PD0,   EXP1_8=PD1,
+    EXP1_9=<GND>, EXP1_10=<5V>,
+
+    # EXP2 header
+    EXP2_1=PA6,   EXP2_2=PA5,
+    EXP2_3=PC6,   EXP2_4=PA4,
+    EXP2_5=PC7,   EXP2_6=PA7,
+    EXP2_7=PB10,  EXP2_8=<RST>,
+    EXP2_9=<GND>, EXP2_10=<5V>
+

--- a/firmware_configurations/klipper/clee/fysetc_s6/v0-fysetc_s6_v2.1.cfg
+++ b/firmware_configurations/klipper/clee/fysetc_s6/v0-fysetc_s6_v2.1.cfg
@@ -1,0 +1,324 @@
+# This file contains common pin mappings for the FYSETC S6 V2.1
+# To use this config, the firmware should be compiled for the
+# STM32F446 with a "32KiB bootloader", "12MHz crystal" Clock reference,
+# and USB (on PA11/PA12) Communication interface.
+
+# This board can be flashed with `make flash FLASH_DEVICE=0483:df11` by
+# booting the MCU with a jumper connecting the BOOT0 pin to 3.3V.
+
+
+## clee's VORON 0.1 FYSETC S6 V2.1 config
+
+## *** THINGS TO CHANGE/CHECK: ***
+## MCU path                                                                     [mcu] section
+## Z and Extruder motor currents                                                [tmc2209 stepper_*] sections. Uncomment the stepper motor you have
+## Full steps per rotation for Extruder                                         [extruder] section
+## Thermistor types                                                             [extruder] and [heater_bed] sections - See 'sensor types' list at end of file
+## Extruder motor currents                                                      [extruder] section
+## PID tune                                                                     [extruder] and [heater_bed] sections
+## Fine tune E steps                                                            [extruder] section
+## For more info                                                                check https://docs.vorondesign.com/build/startup/#v0
+
+[mcu]
+#####################################################################
+# Obtain definition by "ls -l /dev/serial/by-id/"
+#####################################################################
+serial: /dev/serial/by-id/usb-Klipper_stm32f446xx_REPLACE_WITH_YOUR_VALUE
+
+[printer]
+kinematics: corexy
+max_velocity: 200
+max_accel: 2000
+max_z_velocity: 15
+max_z_accel: 45
+square_corner_velocity: 6.0
+
+[include fysetc_s6_v2.1_pin_aliases.cfg]
+#####################################################################
+#      X/Y Stepper Settings
+#####################################################################
+
+[stepper_x]
+step_pin: MOT0_STEP
+## Refer to https://docs.vorondesign.com/build/startup/#v0
+dir_pin: MOT0_DIR                                                   # Check motor direction in link above. If inverted, add a ! before PB12
+enable_pin: !MOT0_EN
+rotation_distance: 40
+microsteps: 32
+full_steps_per_rotation: 200                                        # Set to 400 for 0.9° degree stepper motor, 200 is for 1.8° stepper motors
+endstop_pin: ^!ESTOP0
+position_endstop: 120
+position_max: 120
+homing_speed: 50                                                    # Can be increased after initial setup, Max 100
+homing_retract_dist: 5
+homing_positive_dir: true
+
+[tmc2209 stepper_x]
+uart_pin: MOT0_CS
+interpolate: False
+run_current: 0.5
+stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
+
+[stepper_y]
+step_pin: MOT1_STEP
+## Refer to https://docs.vorondesign.com/build/startup/#v0
+dir_pin: MOT1_DIR                                                   # Check motor direction in link above. If inverted, add a ! before PB2
+enable_pin: !MOT1_EN
+rotation_distance: 40
+microsteps: 32
+full_steps_per_rotation: 200                                        # Set to 400 for 0.9° degree stepper motor, 200 is for 1.8° stepper motors
+endstop_pin: ^!ESTOP1
+position_endstop: 120
+position_max: 120
+homing_speed: 50                                                    # Can be increased after initial setup, Max 100
+homing_retract_dist: 5
+homing_positive_dir: true
+
+[tmc2209 stepper_y]
+uart_pin: MOT1_CS
+interpolate: False
+run_current: 0.5
+stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
+
+#####################################################################
+#   Z Stepper Settings
+#####################################################################
+
+[stepper_z]
+step_pin: MOT2_STEP
+dir_pin: !MOT2_DIR                                                  # Remove the ! before PC5 if motor direction is inverted.
+enable_pin: !MOT2_EN
+rotation_distance: 8                                                # For T8x8 integrated lead screw
+microsteps: 32
+endstop_pin: ^ESTOP2
+position_endstop: -0.10
+position_max: 120
+position_min: -1.5
+homing_speed: 10
+second_homing_speed: 3.0
+homing_retract_dist: 3.0
+
+[tmc2209 stepper_z]
+uart_pin: MOT2_CS
+interpolate: False
+## For OMC (StepperOnline) 17LS13-0404E-200G 0.4A 
+#run_current: 0.2
+## For LDO-42STH25-1004CL200E 1.0A
+#run_current: 0.37
+stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
+
+#####################################################################
+#	Thermistor definitions
+#####################################################################
+
+[thermistor Trianglelab NTC100K B3950]
+## values calibrated against a PT100 reference
+temperature1: 25.0
+resistance1: 103180.0
+temperature2: 150.0
+resistance2: 1366.2
+temperature3: 250.0
+resistance3: 168.6
+
+#####################################################################
+#   Extruder
+#####################################################################
+
+[extruder]
+step_pin: MOT3_STEP
+dir_pin: MOT3_DIR                                                   # Add ! if moving opposite direction
+enable_pin: !MOT3_DIR
+#full_steps_per_rotation: 200                                       # Set to 200 for LDO 1.8° stepper motor, and set to 400 for OMC(StepperOnline) 0.9° stepper motor
+rotation_distance: 22.23                                            # See calibrating rotation_distance on extruders doc
+gear_ratio: 50:10                                                   # For Mini Afterburner
+microsteps: 32
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: HE0
+##  Validate the following thermistor type to make sure it is correct
+##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
+#sensor_type: Trianglelab NTC100K B3950                             # Adjust for your hotend thermistor.
+sensor_pin: T0
+control: pid                                                        # Do PID calibration after initial checks
+pid_Kp: 28.182
+pid_Ki: 1.978
+pid_Kd: 100.397
+min_temp: 0
+max_temp: 270
+min_extrude_temp: 170
+max_extrude_only_distance: 150
+max_extrude_cross_section: 0.8
+pressure_advance: 0.0                                               # See tuning pressure advance doc
+pressure_advance_smooth_time: 0.040
+
+[tmc2209 extruder]
+uart_pin: MOT3_CS
+interpolate: False
+## For OMC (StepperOnline) 14HR07-1004VRN 1A 0.9°
+#run_current: 0.5	# for OMC 14HR07-1004VRN rated at 1A
+## For LDO LDO 36STH17-1004AHG 1A 1.8° 
+#run_current: 0.3	# for LDO 36STH17-1004AHG
+stealthchop_threshold: 0                                            # Set to 0 for spreadcycle, avoid using stealthchop on extruder
+
+#[extruder1]
+#step_pin: MOT4_STEP
+#dir_pin: !MOT4_DIR
+#enable_pin: !MOT4_EN
+#heater_pin: HE1
+#sensor_pin: T1
+
+#[tmc2209 extruder1]
+#uart_pin: MOT4_CS
+## For OMC (StepperOnline) 14HR07-1004VRN 1A 0.9°
+#run_current: 0.5	# for OMC 14HR07-1004VRN rated at 1A
+## For LDO LDO 36STH17-1004AHG 1A 1.8° 
+#run_current: 0.3	# for LDO 36STH17-1004AHG
+#stealthchop_threshold: 0
+
+#[extruder2]
+#step_pin: MOT5_STEP
+#dir_pin: !MOT5_DIR
+#enable_pin: !MOT5_EN
+#heater_pin: HE2
+#sensor_pin: T2
+
+#[tmc2209 extruder2]
+#uart_pin: MOT5_CS
+## For OMC (StepperOnline) 14HR07-1004VRN 1A 0.9°
+#run_current: 0.5	# for OMC 14HR07-1004VRN rated at 1A
+## For LDO LDO 36STH17-1004AHG 1A 1.8° 
+#run_current: 0.3	# for LDO 36STH17-1004AHG
+#stealthchop_threshold: 0
+
+#####################################################################
+#   Bed Heater
+#####################################################################
+
+[heater_bed]
+heater_pin: BED_OUT
+##  Validate the following thermistor type to make sure it is correct
+##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
+#sensor_type: Generic 3950                                          # For Keenovo, verify yours
+sensor_pin: TB
+smooth_time: 3.0
+#max_power: 0.6                                                     # Only needed for 100w pads
+min_temp: 0
+max_temp: 120
+control: pid                                                        # Do PID calibration after initial checks
+pid_kp: 68.453
+pid_ki: 2.749
+pid_kd: 426.122
+
+#####################################################################
+#	Fan Control
+#####################################################################
+
+[heater_fan hotend_fan]
+# FAN0
+pin: FAN0
+max_power: 1.0
+kick_start_time: 0.5
+heater: extruder
+heater_temp: 50.0
+#fan_speed: 1.0	                                                    # You can't PWM the delta fan unless using blue wire
+
+[fan]
+# FAN1
+pin: FAN1
+max_power: 1.0
+kick_start_time: 0.5                                                # Depending on your fan, you may need to increase this value if your fan will not start
+off_below: 0.13
+cycle_time: 0.010
+
+#[fan_generic nevermore]
+## FAN2
+#pin: FAN2
+#max_power: 1.0
+#kick_start_time: 0.5                                                # Depending on your fan, you may need to increase this value if your fan will not start
+#off_below: 0.13
+#cycle_time: 0.010
+
+#####################################################################
+#	Homing and Gantry Adjustment Routines
+#####################################################################
+
+[idle_timeout]
+timeout: 1800
+
+[safe_z_home]
+home_xy_position: 120,120
+speed: 50.0
+z_hop: 5
+
+## To be used with BED_SCREWS_ADJUST
+[bed_screws]
+screw1: 60,5
+screw1_name: front screw
+screw2: 5,115
+screw2_name: back left
+screw3: 115,115
+screw3_name: back right
+
+#####################################################################
+#	Macros
+#####################################################################
+
+[gcode_macro PRINT_START]
+#   Use PRINT_START for the slicer starting script - please customize for your slicer of choice
+gcode:
+    G28                            ; home all axes
+    G1 Z20 F3000                   ; move nozzle away from bed
+   
+[gcode_macro PRINT_END]
+#   Use PRINT_END for the slicer ending script - please customize for your slicer of choice
+gcode:
+    M400                           ; wait for buffer to clear
+    G92 E0                         ; zero the extruder
+    G1 E-4.0 F3600                 ; retract filament
+    G91                            ; relative positioning
+
+    #   Get Boundaries
+    {% set max_x = printer.configfile.config["stepper_x"]["position_max"]|float %}
+    {% set max_y = printer.configfile.config["stepper_y"]["position_max"]|float %}
+    {% set max_z = printer.configfile.config["stepper_z"]["position_max"]|float %}
+
+    #   Check end position to determine safe direction to move
+    {% if printer.toolhead.position.x < (max_x - 20) %}
+        {% set x_safe = 20.0 %}
+    {% else %}
+        {% set x_safe = -20.0 %}
+    {% endif %}
+
+    {% if printer.toolhead.position.y < (max_y - 20) %}
+        {% set y_safe = 20.0 %}
+    {% else %}
+        {% set y_safe = -20.0 %}
+    {% endif %}
+
+    {% if printer.toolhead.position.z < (max_z - 2) %}
+        {% set z_safe = 2.0 %}
+    {% else %}
+        {% set z_safe = max_z - printer.toolhead.position.z %}
+    {% endif %}
+
+    G0 Z{z_safe} F3600             ; move nozzle up
+    G0 X{x_safe} Y{y_safe} F20000  ; move nozzle to remove stringing
+    TURN_OFF_HEATERS
+    M107                           ; turn off fan
+    G90                            ; absolute positioning
+    G0 X60 Y{max_y} F3600          ; park nozzle at rear
+	
+[gcode_macro LOAD_FILAMENT]
+gcode:
+   M83                            ; set extruder to relative
+   G1 E30 F300                    ; load
+   G1 E15 F150                    ; prime nozzle with filament
+   M82                            ; set extruder to absolute
+    
+[gcode_macro UNLOAD_FILAMENT]
+gcode:
+   M83                            ; set extruder to relative
+   G1 E10 F300                    ; extrude a little to soften tip
+   G1 E-40 F1800                  ; retract some, but not too much or it will jam
+   M82                            ; set extruder to absolute
+


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to the VoronUsers repository, it is
highly appreciated!

**Please make sure the submission conforms to the rules outlined below. PRs which fail
to conform to the rules below are likely to be rejected.**
-->

  * [x] The mod, firmware configuration or slicer profile is in the correct category
    folder. Printable mods go to `printer_mods/`, firmware configurations
    go to `firmware_configurations/`, slicer profiles go to `slicer_profiles/`.
    Create a subfolder with your name, and place the mods in a subfolder with
    a descriptive name within that folder, e.g.: `/printer_mods/FHeilmann/flux_capacitor`
  * [x] Folders names MUST NOT contain spaces. If possible, make sure file names also 
    do not contain any spaces.
  * [x] The PR modifies the top-level `README.md` of the category folder adding the 
    contribution to the table. Read the top part of the file for instructions on how
    to do this. Please preserve the alphabetical ordering while adding new rows. Make sure
    to fill out the compatibility matrix to indicate which versions of the Voron printer
    the submission is compatible with.
  * [ ] The mod/configuration/profile has been tested by the person submitting the mod 
    and/or other Voron users. Make sure to add information about how the mod was tested below. 
  * [x] The mod is not merely a slight modification of an official Voron part, configuration 
    or profile (i.e. an official Voron part with a few mm added or removed or a slicer profile 
    which only modifies a few values). *(When in doubt, contact one of the admins in the 
    Voron discord before submitting the PR)*
  * [x] Submitted firmware configs or slicer profiles contain no sensitive data (e.g. API keys).

<!--
Describe the submission further using the template provided below. The more 
details the better!
-->

#### Which mods/configurations/profiles are added by this PR?

V0.1 example config for Fysetc S6 V2.1, along with separate board pin aliases for other printers.

#### How was it tested? 

I have not tested this specific config with my V0.1, but the pins are all taken from my working config. This needs testing and verification from someone else.

#### Any background context you want to provide?

The S6 supports up to six stepper drivers, which means it's usable for V0.1, Trident, Tri-Zero, and Salad Fork.