### PR TITLE
Position for purge only if able to purge

### DIFF
--- a/abandoned_mods/printer_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
+++ b/abandoned_mods/printer_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
@@ -170,17 +170,19 @@ gcode:
             G1 Y{brush_front + (brush_depth / 2)} F{prep_spd_xy}
          {% endif %}
 
-         ### Position for purge. Randomly selects middle of left or right bucket. It references from the middle of the left bucket.
-         G1 X{bucket_start + (bucket_left_width / (2 - bucket_pos)) + (bucket_pos * bucket_gap) + (bucket_pos * (bucket_right_width / 2))}
-
          ### Perform purge if the temp is up to min temp. If not, it will skip and continue executing rest of macro. Small retract after
          ### purging to minimize any persistent oozing at 5x purge_spd. G4 dwell is in milliseconds, hence * 1000 in formula.
          {% if printer.extruder.temperature >= purge_temp_min %}
+            
+            ### Position for purge. Randomly selects middle of left or right bucket. It references from the middle of the left bucket.
+            G1 X{bucket_start + (bucket_left_width / (2 - bucket_pos)) + (bucket_pos * bucket_gap) + (bucket_pos * (bucket_right_width / 2))}
+            
             M83      ; relative mode
             G1 E{purge_len} F{purge_spd}
             G1 E-{purge_ret} F{purge_spd * 5}
             G4 P{ooze_dwell * 1000}
             G92 E0   ; reset extruder
+            
          {% endif %}
 
       {% endif %}


### PR DESCRIPTION
Skip moving to the purge position if the extruder temperature is lower than `purge_temp_min` and move directly to wipe position.

<!--
Thank you for your interest in contributing to the VoronUsers repository, it is
highly appreciated!

**Please make sure the submission conforms to the rules outlined below. PRs which fail
to conform to the rules below are likely to be rejected.**
-->

  * [x] The mod, firmware configuration or slicer profile is in the correct category
    folder. Printable mods go to `printer_mods/`, firmware configurations
    go to `firmware_configurations/`, slicer profiles go to `slicer_profiles/`.
    Create a subfolder with your name, and place the mods in a subfolder with
    a descriptive name within that folder, e.g.: `/printer_mods/FHeilmann/flux_capacitor`
  * [x] Folder and file naming:
    * Folders and filenames shouldn't contain spaces. Only letters `a-zA-Z`, numbers `0-9`, underscores `_`, hyphens `-` and periods `.`
    * Primary color: `part_xyz.stl`
    * Accent color: `[a]_part_xyz.stl`
    * Opaque color (Blocks light): `[o]_part_xyz.stl`
    * Clear/transparent color (Allows light): `[c]_part_xyz.stl`
    * Quantity, if more than one is needed: `part_xyz_x4.stl`
  * [ ] For each mod, add a small `README.md` file to its folder with a short description
    of what the mod accomplishes. This readme can be used to add pictures, give assembly
    instructions or specify a bill of materials if the mod requires additional hardware.
  * [ ] The PR modifies the top-level `README.md` of the category folder adding the 
    contribution to the table. Read the top part of the file for instructions on how
    to do this. Please preserve the alphabetical ordering while adding new rows. Make sure
    to fill out the compatibility matrix to indicate which versions of the Voron printer
    the submission is compatible with.
  * [x] The mod/configuration/profile has been tested by the person submitting the mod 
    and/or other Voron users. Make sure to add information about how the mod was tested below. 
  * [x] The mod is not merely a slight modification of an official Voron part, configuration 
    or profile (i.e. an official Voron part with a few mm added or removed or a slicer profile 
    which only modifies a few values). *(When in doubt, contact one of the admins in the 
    Voron discord before submitting the PR)*
  * [ ] Submitted STLs are printable without support. *(If the mod does not meet this criterion
    join the Voron discord and ask the other users for advice on how to modify the mod such 
    that it does not require supports)*
  * [ ] Submitted STL files are not corrupt. *(This can be tested by opening the STL in PrusaSlicer
    and checking if mesh errors are reported.)*
  * [ ] Submitted STL files are oriented and scaled properly for printing.
  * [ ] Submission includes a CAD file in the form of a `.STEP` or `.SCAD` file
  * [ ] Submitted firmware configs or slicer profiles contain no sensitive data (e.g. API keys).

<!--
Describe the submission further using the template provided below. The more 
details the better!
-->

#### Which mods/configurations/profiles are added by this PR?
Decontaminator Purge Bucket & Nozzle Scrubber
#### How was it tested? 
On my V2.4r2
#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Further notes
