### PR TITLE
Fix image links (270° door hinges)

### DIFF
--- a/printer_mods/AlexanderT-Moss/270-Clamping-Hinges/README.md
+++ b/printer_mods/AlexanderT-Moss/270-Clamping-Hinges/README.md
@@ -25,7 +25,7 @@
 
  Face Plate No Logo               |  Face Plate Embossed Logo         | Face Plate Through Logo
  :-------------------------------:|:-------------------------------:|:-------------------------------:
- ![Logo-Variation-0.png](https://github.com/Alexander-T-Moss/VoronUsers/blob/master/printer_mods/AlexanderT-Moss/270-Clamping-Hinges/Images/Logo-Variation-0.png?raw=true)         |  ![Logo-Variation-1.png](https://github.com/Alexander-T-Moss/VoronUsers/blob/master/printer_mods/AlexanderT-Moss/270-Clamping-Hinges/Images/Logo-Variation-1.png?raw=true)  | ![Logo-Variation-2](https://github.com/Alexander-T-Moss/VoronUsers/blob/master/printer_mods/AlexanderT-Moss/270-Clamping-Hinges/Images/Logo-Variation-2.png?raw=true)
+ ![Logo-Variation-0.png](https://github.com/VoronDesign/VoronUsers/blob/master/printer_mods/AlexanderT-Moss/270-Clamping-Hinges/Images/Logo-Variation-0.png?raw=true)         |  ![Logo-Variation-1.png](https://github.com/VoronDesign/VoronUsers/blob/master/printer_mods/AlexanderT-Moss/270-Clamping-Hinges/Images/Logo-Variation-1.png?raw=true)  | ![Logo-Variation-2](https://github.com/VoronDesign/VoronUsers/blob/master/printer_mods/AlexanderT-Moss/270-Clamping-Hinges/Images/Logo-Variation-2.png?raw=true)
 
  ## BOM - Per Hinge ##
  **Printed Parts**
@@ -54,7 +54,7 @@
  ```
  ## Assembly ##
 
- ![Clamping-Hinges-Assembly.gif](https://github.com/Alexander-T-Moss/VoronUsers/blob/master/printer_mods/AlexanderT-Moss/270-Clamping-Hinges/Images/270-Clamping-Hinges-Assembly.gif?raw=true)
+ ![Clamping-Hinges-Assembly.gif](https://github.com/VoronDesign/VoronUsers/blob/master/printer_mods/AlexanderT-Moss/270-Clamping-Hinges/Images/270-Clamping-Hinges-Assembly.gif?raw=true)
  _Better photos will come in good time ;)_
 
  1. Attach the _face_plate_bottom_ to the _face_plate_top_ using 2x M3 x 8 mm Bolts and 2x Hex Nuts - Keep the bolts loose for now
@@ -66,5 +66,5 @@
 
  ## Installed On My 2.4 ##
 
- ![IMG_0310.PNG](https://github.com/Alexander-T-Moss/VoronUsers/blob/master/printer_mods/AlexanderT-Moss/270-Clamping-Hinges/Images/IMG_0310.png?raw=true)
+ ![IMG_0310.PNG](https://github.com/VoronDesign/VoronUsers/blob/master/printer_mods/AlexanderT-Moss/270-Clamping-Hinges/Images/IMG_0310.png?raw=true)
  _Better photos will come in good time ;)_


### PR DESCRIPTION
The image links still pointed to the author’s Github account, instead of the local VoronUsers one.

# Before

> ![image](https://user-images.githubusercontent.com/3020161/201723801-54eb5ff7-d27a-49bc-87cc-7336a8d2bbb5.png)

# After (using Github’s preview button)

> ![image](https://user-images.githubusercontent.com/3020161/201723742-1e55ee2e-4c3c-4287-a0e2-f62d7c6cd878.png)
