### PR TITLE
add pin aliases for SKR Pico v1.0

### DIFF
--- a/firmware_configurations/README.md
+++ b/firmware_configurations/README.md
@@ -5,8 +5,8 @@ Remember to update this README when uploading new firmware configurations!
 
 ## Legacy printers
 
-Configurations for legacy printers can be found [here](../legacy_printers/firmware_configurations). 
-If one of your configurations applies to a current generation Voron printer, contact the admins in 
+Configurations for legacy printers can be found [here](../legacy_printers/firmware_configurations).
+If one of your configurations applies to a current generation Voron printer, contact the admins in
 Discord to have your mod moved to this folder.
 
 ## Table structure
@@ -38,6 +38,7 @@ like so:
 | RealDeuce | [MKS Makerbase Monster8 v1.0_003](./klipper/RealDeuce/MKS-Makerbase/Monster8_v1.0_003/) | Configuration and instructions for installing an MKS Makerbase Monster8 board | :x: | :x: | :heavy_check_mark: | :x: | :x: |
 | TechnoPhreak | [BTT SKR v2 for V2.4](./klipper/TechnoPhreak/BTT_SKR_v2) | Example configuration, wiring diagram and special instructions for the BTT SKR v2 controllers | :grey_question: | :grey_question: | :heavy_check_mark: | :grey_question: |
 | redelman | [Fysetc Spider 2.2 for Voron Trident](./klipper/redelman/Spider_2.2_Voron_Trident) | Example configuration and special instructions for the Fysetc Spider 2.2 for VT | :x: | :x: | :x: | :x: | :heavy_check_mark: |
+| [kdomanski](https://www.github.com/kdomanski) | [SKR Pico v1.0 board pins](./klipper/skr_pico) | Pin aliases for the SKR Pico V1.0 board | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: | :x: |
 
 ---
 

--- a/firmware_configurations/klipper/skr_pico/pico_pins.cfg
+++ b/firmware_configurations/klipper/skr_pico/pico_pins.cfg
@@ -1,0 +1,13 @@
+[board_pins pico]
+aliases:
+  RXD0=gpio1, TXD0=gpio0,
+  RXD4=gpio9, TXD4=gpio8,
+
+  X_DIR=gpio10, X_STEP=gpio11, X_EN=gpio12, X_STOP=gpio4,
+  Y_DIR=gpio5,  Y_STEP=gpio6,  Y_EN=gpio7,  Y_STOP=gpio3,
+  Z_DIR=gpio28, Z_STEP=gpio19, Z_EN=gpio2,  Z_STOP=gpio25,
+  E_DIR=gpio13, E_STEP=gpio14, E_EN=gpio15, E_STOP=gpio16,
+
+  FAN_1=gpio17, FAN_2=gpio18, FAN_3=gpio20,
+  THB=gpio26, TH0=gpio27, HB_PWM=gpio21, HE_PWM=gpio23,
+  RGB=gpio24, P2=gpio22, SERVOS=gpio29


### PR DESCRIPTION
  * [x] The mod, firmware configuration or slicer profile is in the correct category
    folder. Printable mods go to `printer_mods/`, firmware configurations
    go to `firmware_configurations/`, slicer profiles go to `slicer_profiles/`.
    Create a subfolder with your name, and place the mods in a subfolder with
    a descriptive name within that folder, e.g.: `/printer_mods/FHeilmann/flux_capacitor`
  * [x] Folder and file naming:
    * Folders and filenames shouldn't contain spaces. Only letters `a-zA-Z`, numbers `0-9`, underscores `_`, hyphens `-` and periods `.`
    * Primary color: `part_xyz.stl`
    * Accent color: `[a]_part_xyz.stl`
    * Opaque color (Blocks light): `[o]_part_xyz.stl`
    * Clear/transparent color (Allows light): `[c]_part_xyz.stl`
    * Quantity, if more than one is needed: `part_xyz_x4.stl`
  * [ ] For each mod, add a small `README.md` file to its folder with a short description
    of what the mod accomplishes. This readme can be used to add pictures, give assembly
    instructions or specify a bill of materials if the mod requires additional hardware.
  * [x] The PR modifies the top-level `README.md` of the category folder adding the 
    contribution to the table. Read the top part of the file for instructions on how
    to do this. Please preserve the alphabetical ordering while adding new rows. Make sure
    to fill out the compatibility matrix to indicate which versions of the Voron printer
    the submission is compatible with.
  * [x] The mod/configuration/profile has been tested by the person submitting the mod 
    and/or other Voron users. Make sure to add information about how the mod was tested below. 
  * [x] The mod is not merely a slight modification of an official Voron part, configuration 
    or profile (i.e. an official Voron part with a few mm added or removed or a slicer profile 
    which only modifies a few values). *(When in doubt, contact one of the admins in the 
    Voron discord before submitting the PR)*
  * [ ] ~~Submitted STLs are printable without support. *(If the mod does not meet this criterion
    join the Voron discord and ask the other users for advice on how to modify the mod such 
    that it does not require supports)*~~
  * [ ] ~~Submitted STL files are not corrupt. *(This can be tested by opening the STL in PrusaSlicer
    and checking if mesh errors are reported.)*~~
  * [ ] ~~Submitted STL files are oriented and scaled properly for printing.~~
  * [ ] ~~Submission includes a CAD file in the form of a `.STEP` or `.SCAD` file~~
  * [x] Submitted firmware configs or slicer profiles contain no sensitive data (e.g. API keys).

<!--
Describe the submission further using the template provided below. The more 
details the better!
-->

#### Which mods/configurations/profiles are added by this PR?
Klipper pin aliases for SKR Pico

#### How was it tested? 
I'm using them myself on my Switchwire

#### ~~Any background context you want to provide?~~

#### ~~Screenshots (if appropriate)~~

#### ~~Further notes~~
