### PR TITLE
allow more configuration for bucket selections

### DIFF
--- a/orphaned_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
+++ b/orphaned_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
@@ -128,6 +128,9 @@ variable_bucket_gap:           22
 # installation of purge bucket at rear left.
 variable_bucket_start: 0
 
+# Which bucket should the purge be done? -1 = random, 0 = left, 1 = right
+variable_bucket_purge:          -1
+
 # Which bucket should we park the nozzle at the end of purge? 0 = left, 1 = right
 variable_bucket_park:           0
 
@@ -157,8 +160,12 @@ gcode:
       ## Check if user enabled purge option or not.
       {% if enable_purge %}
 
-         ### Randomly select left or right bin for purge. 0 = left, 1 = right
-         {% set _bucket_pos = (range(2) | random) %}
+         {% if bucket_purge < 0 %}
+            ### Randomly select left or right bin for purge. 0 = left, 1 = right
+            {% set _bucket_pos = (range(2) | random) %}
+         {% else %}
+            {% set _bucket_pos = bucket_purge %}
+         {% endif %}
 
          ### Raise Z for travel.
          G1 Z{brush_top + clearance_z} F{prep_spd_z}

--- a/orphaned_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
+++ b/orphaned_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
@@ -128,6 +128,9 @@ variable_bucket_gap:           22
 # installation of purge bucket at rear left.
 variable_bucket_start: 0
 
+# Which bucket should we park the nozzle at the end of purge? 0 = left, 1 = right
+variable_bucket_park:           0
+
 
 ###############################################################################################################################################
 ###############################################################################################################################################
@@ -205,7 +208,7 @@ gcode:
       ## Clear from area.
       M117 Cleaned!
       G1 Z{brush_top + clearance_z} F{prep_spd_z}
-      G1 X{bucket_start + (bucket_left_width / 4)} F{prep_spd_xy} #bugfix for right side mounted buckets
+      G1 X{bucket_start + (bucket_left_width * (1 + (3 * bucket_park)) / 4) + (bucket_park * bucket_gap) + (bucket_park * (bucket_right_width / 2))} F{prep_spd_xy} #bugfix for right side mounted buckets
 
       ## Restore the gcode state to how it was before the macro.
       RESTORE_GCODE_STATE NAME=clean_nozzle

--- a/orphaned_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
+++ b/orphaned_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
@@ -138,9 +138,6 @@ variable_bucket_start: 0
 ###############################################################################################################################################
 ###############################################################################################################################################
 
-# Placeholder. The variable will later be set to contain, at random, a number representing the left or right bucket.
-variable_bucket_pos:            1	        
-
 gcode:
    # First, check if the axes are homed.
    {% if "xyz" in printer.toolhead.homed_axes %}
@@ -158,7 +155,7 @@ gcode:
       {% if enable_purge %}
 
          ### Randomly select left or right bin for purge. 0 = left, 1 = right
-         SET_GCODE_VARIABLE MACRO=clean_nozzle VARIABLE=bucket_pos VALUE={(range(2) | random)}
+         {% set _bucket_pos = (range(2) | random) %}
 
          ### Raise Z for travel.
          G1 Z{brush_top + clearance_z} F{prep_spd_z}
@@ -171,7 +168,7 @@ gcode:
          {% endif %}
 
          ### Position for purge. Randomly selects middle of left or right bucket. It references from the middle of the left bucket.
-         G1 X{bucket_start + (bucket_left_width / (2 - bucket_pos)) + (bucket_pos * bucket_gap) + (bucket_pos * (bucket_right_width / 2))}
+         G1 X{bucket_start + (bucket_left_width / (2 - _bucket_pos)) + (_bucket_pos * bucket_gap) + (_bucket_pos * (bucket_right_width / 2))}
 
          ### Perform purge if the temp is up to min temp. If not, it will skip and continue executing rest of macro. Small retract after
          ### purging to minimize any persistent oozing at 5x purge_spd. G4 dwell is in milliseconds, hence * 1000 in formula.
@@ -185,9 +182,9 @@ gcode:
 
       {% endif %}
    
-      ## Position for wipe. Either left or right of brush based off bucket_pos to avoid unnecessary travel.
+      ## Position for wipe. Either left or right of brush based off _bucket_pos to avoid unnecessary travel.
       G1 Z{brush_top + clearance_z} F{prep_spd_z}
-      G1 X{brush_start + (brush_width * bucket_pos)} F{prep_spd_xy}
+      G1 X{brush_start + (brush_width * _bucket_pos)} F{prep_spd_xy}
 
       ## Check if user chose to use rear location.
       {% if location_bucket_rear %}
@@ -199,10 +196,10 @@ gcode:
       ## Move nozzle down into brush.
       G1 Z{brush_top} F{prep_spd_z}
    
-      ## Perform wipe. Wipe direction based off bucket_pos for cool random scrubby routine.
+      ## Perform wipe. Wipe direction based off _bucket_pos for cool random scrubby routine.
       {% for wipes in range(1, (wipe_qty + 1)) %}
-         G1 X{brush_start + (brush_width * (1 - bucket_pos))} F{wipe_spd_xy}
-         G1 X{brush_start + (brush_width * bucket_pos)} F{wipe_spd_xy}
+         G1 X{brush_start + (brush_width * (1 - _bucket_pos))} F{wipe_spd_xy}
+         G1 X{brush_start + (brush_width * _bucket_pos)} F{wipe_spd_xy}
       {% endfor %}
    
       ## Clear from area.


### PR DESCRIPTION
### Which mods are added by this PR?
This allows more control over which bucket is selected for purging and for parking the nozzle after cleaning in the Decontaminator Purge Bucket & Nozzle Scrubber mod,

### How was it tested?
I tested this modification on my Voron v2.4 350 build with all the combinations of new configuration options. The final implementation behaves with all combinations as expected.

### Any background context you want to provide?
This includes the following three modifications:
1. use native Jinja variable _bucket_pos
   
   The previous implementation of dynamically changing bucket_pos on each
   run had an extremely confusing semantic of changing the variable early
   in the execution of the macro but see the effect only on the next run of
   the macro.  This led to the situation that the first bucket position
   after the machine started was never selected randomly, only all later
   ones.  While this for sure is not a major problem of the implementation
   it is extremely confusing and makes extending the macro unnecessarily
   complicated.
   
   See the confusion this created on my side at
   https://klipper.discourse.group/t/conditional-changing-of-a-variable-inside-a-macro/19161
   
   By using the native Jinja variable _bucket_pos instead, we can make the
   change effective immediately, making the macro behave how you would
   intuitively expect.
2. variable_bucket_park: select bucket to park nozzle after cleaning
   
   The previous implementation always parked the nozzle over the left
   bucket after cleaning.  While this makes sense in most cases it is
   problematic when you happen to have something installed over the left
   bucket, like the Klicky Probe.  If parking the nozzle over the Klicky
   Probe there is a certain risk to pull it out of the docking station by
   accident with the move command following the cleaning procedure.  When
   we park the nozzle over the right bucket we can mitigate that risk.
   
   The default value for variable_bucket_park is still to park over the
   left bucket as in the original implementation.
3. variable_bucket_purge: select bucket for purging
   
   In the original implementation, the bucket for purging was selected
   randomly.  Since I wanted to park the nozzle always over the right
   bucket to avoid conflicts with the Klicky Probe and as such always
   oozing into that (on my 350 build) smaller right bucket I thought that
   it might be useful to compensate for this by always purging to the
   larger left bucket.
   
   Now you can select the bucket you want to do the purging.  With the
   default setting of -1 it will still randomly choose the bucket as
   before.

### ⚠️⚠️**PLEASE READ AND COMPLETE THE CHECKLIST BELOW**⚠️⚠️

  * [X] I have read the rules available [here](https://github.com/VoronDesign/VoronUsers/wiki/Mod-Submission-Rules) and
        my mod adheres to these rules.
  * [X] This mod was created by myself and I agree to publish it under the repository
        [license](https://github.com/VoronDesign/VoronUsers/blob/master/LICENSE.md)
