### PR TITLE
Update nozzlewiper.cfg - Wait for servo move before turning off

### DIFF
--- a/printer_mods/chirpy/NozzleWiper/nozzlewiper.cfg
+++ b/printer_mods/chirpy/NozzleWiper/nozzlewiper.cfg
@@ -73,6 +73,8 @@ gcode:
 [gcode_macro NW_RETRACT]
 gcode:
     SET_SERVO SERVO=wipeServo ANGLE=120
+    G4 P500 # The below line turns the servo off. 
+            # It may need some time to reach the target angle. 
     SET_SERVO SERVO=wipeServo WIDTH=0 # OFF
     G4 P500
 


### PR DESCRIPTION
Fix for existing mod. 

The servo was turned off before it reached target angle, which caused crashes.  Simple fix. 

  * [ x] I have read the rules available [here](https://github.com/VoronDesign/VoronUsers/wiki/Mod-Submission-Rules) and
        my mod adheres to these rules.
  * [x ] This mod was created by myself and I agree to publish it under the repository
        [license](https://github.com/VoronDesign/VoronUsers/blob/master/LICENSE.md)
