### PR TITLE
factor out park_nozzle

### DIFF
--- a/orphaned_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
+++ b/orphaned_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber/Macros/nozzle_scrub.cfg
@@ -154,8 +154,8 @@ gcode:
       ## Set to absolute positioning.
       G90
 
-      ## Grab max position of Y-axis from config to use in setting a fixed y position for location_bucket_rear = True.
-      {% set Ry = printer.configfile.config["stepper_y"]["position_max"]|float %}
+      ## Calculate y position of the brush.
+      {% set Ry = printer.configfile.config["stepper_y"]["position_max"] if location_bucket_rear else brush_front + (brush_depth / 2) |float %}
 
       ## Check if user enabled purge option or not.
       {% if enable_purge %}
@@ -170,12 +170,8 @@ gcode:
          ### Raise Z for travel.
          G1 Z{brush_top + clearance_z} F{prep_spd_z}
 
-         ### Check if user chose to use rear location.
-         {% if location_bucket_rear %}
-            G1 Y{Ry} F{prep_spd_xy}
-         {% else %}
-            G1 Y{brush_front + (brush_depth / 2)} F{prep_spd_xy}
-         {% endif %}
+         ### Position on the y position of the brush.
+         G1 Y{Ry} F{prep_spd_xy}
 
          ### Position for purge. Randomly selects middle of left or right bucket. It references from the middle of the left bucket.
          G1 X{bucket_start + (bucket_left_width / (2 - _bucket_pos)) + (_bucket_pos * bucket_gap) + (_bucket_pos * (bucket_right_width / 2))}
@@ -196,12 +192,8 @@ gcode:
       G1 Z{brush_top + clearance_z} F{prep_spd_z}
       G1 X{brush_start + (brush_width * _bucket_pos)} F{prep_spd_xy}
 
-      ## Check if user chose to use rear location.
-      {% if location_bucket_rear %}
-         G1 Y{Ry}
-      {% else %}
-         G1 Y{brush_front + (brush_depth / 2)}
-      {% endif %}
+      ## Position on the y position of the brush.
+      G1 Y{Ry}
 
       ## Move nozzle down into brush.
       G1 Z{brush_top} F{prep_spd_z}
@@ -215,7 +207,7 @@ gcode:
       ## Clear from area.
       M117 Cleaned!
       G1 Z{brush_top + clearance_z} F{prep_spd_z}
-      G1 X{bucket_start + (bucket_left_width * (1 + (3 * bucket_park)) / 4) + (bucket_park * bucket_gap) + (bucket_park * (bucket_right_width / 2))} F{prep_spd_xy} #bugfix for right side mounted buckets
+      park_nozzle
 
       ## Restore the gcode state to how it was before the macro.
       RESTORE_GCODE_STATE NAME=clean_nozzle
@@ -227,3 +219,17 @@ gcode:
       M117 Please home first!
 
    {% endif %}
+
+[gcode_macro park_nozzle]
+gcode:
+   {% set bucket_start = printer["gcode_macro clean_nozzle"].bucket_start %}
+   {% set bucket_left_width = printer["gcode_macro clean_nozzle"].bucket_left_width %}
+   {% set bucket_park = printer["gcode_macro clean_nozzle"].bucket_park %}
+   {% set bucket_gap = printer["gcode_macro clean_nozzle"].bucket_gap %}
+   {% set bucket_right_width = printer["gcode_macro clean_nozzle"].bucket_right_width %}
+   {% set location_bucket_rear = printer["gcode_macro clean_nozzle"].location_bucket_rear %}
+   {% set brush_front = printer["gcode_macro clean_nozzle"].brush_front %}
+   {% set brush_depth = printer["gcode_macro clean_nozzle"].brush_depth %}
+   {% set Ry = printer.configfile.config["stepper_y"]["position_max"] if location_bucket_rear else brush_front + (brush_depth / 2) |float %}
+   {% set prep_spd_xy = printer["gcode_macro clean_nozzle"].prep_spd_xy %}
+   G1 X{bucket_start + (bucket_left_width * (1 + (3 * bucket_park)) / 4) + (bucket_park * bucket_gap) + (bucket_park * (bucket_right_width / 2))} Y{Ry} F{prep_spd_xy} #bugfix for right side mounted buckets


### PR DESCRIPTION
This factors out the final positioning of the nozzle over the bucket into a separate macro park_nozzle.  Sometimes it is desired to park the nozzle over the bucket without scrubbing the nozzle, for instance when there is a risk that the nozzle might ooze some filament when pausing a print.

This also refactors the calculation of the y position into a single place of calculation instead of calculating it multiple times inside the macro.

### Which mods are added by this PR?
This slightly refactors the orphaned nozzle_scrub macros in the way described above.

### How was it tested?
I tested this code in my Voron 2.4r2 printer, which has the purge bucket and nozzle scrubber installed.

### Any background context you want to provide?
Nothing more than what is said above already.

### Screenshots (if appropriate)
Code change only.

### ⚠️⚠️**PLEASE READ AND COMPLETE THE CHECKLIST BELOW**⚠️⚠️

  * [X] I have read the rules available [here](https://github.com/VoronDesign/VoronUsers/wiki/Mod-Submission-Rules) and
        my mod adheres to these rules.
  * [X] This mod was created by myself and I agree to publish it under the repository
        [license](https://github.com/VoronDesign/VoronUsers/blob/master/LICENSE.md)
